### PR TITLE
    Improve error reporting in case one file cannot be opened.

### DIFF
--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -886,21 +886,21 @@ int main(int argc, char *argv[])
     const wxString url1 = wxT("file://") + file1.GetFullPath(wxPATH_UNIX);
     const wxString url2 = wxT("file://") + file2.GetFullPath(wxPATH_UNIX);
 
-    GError *err;
+    GError *err = NULL;
 
     PopplerDocument *doc1 = poppler_document_new_from_file(url1.utf8_str(), NULL, &err);
     if ( !doc1 )
     {
-        fprintf(stderr, "Error opening %s: %s\n", argv[1], err->message);
-        g_object_unref(err);
+        fprintf(stderr, "Error opening %s: %s\n", (const char*) parser.GetParam(0), err->message);
+        g_error_free(err);
         return 3;
     }
 
     PopplerDocument *doc2 = poppler_document_new_from_file(url2.utf8_str(), NULL, &err);
     if ( !doc2 )
     {
-        fprintf(stderr, "Error opening %s: %s\n", argv[2], err->message);
-        g_object_unref(err);
+        fprintf(stderr, "Error opening %s: %s\n", (const char*) parser.GetParam(1), err->message);
+        g_error_free(err);
         return 3;
     }
 


### PR DESCRIPTION
    * If arguments such as --output-diff or --view are used, the wrong
      file name was reported.

    * Then, the error reporting caused a segfault on OSX
      in g_object_unref. Replaced it by g_error_free, which is used
      in the respective examples in the documentation:
      https://developer.gnome.org/glib/stable/glib-Error-Reporting.html

    * Explicitly initialized GError to NULL.

    At the end, I still don't get the proper error message in case of
    "file not found" (err->message is an empty string) but at least
    it reports the correct command line parameter and does not crash
    afterwards.