### PR TITLE
Urlencode file path before creating URI

### DIFF
--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -40,6 +40,7 @@
 #include <wx/toolbar.h>
 #include <wx/artprov.h>
 #include <wx/progdlg.h>
+#include <wx/filesys.h>
 
 // ------------------------------------------------------------------------
 // PDF rendering functions
@@ -883,8 +884,8 @@ int main(int argc, char *argv[])
     wxFileName file2(parser.GetParam(1));
     file1.MakeAbsolute();
     file2.MakeAbsolute();
-    const wxString url1 = wxT("file://") + file1.GetFullPath(wxPATH_UNIX);
-    const wxString url2 = wxT("file://") + file2.GetFullPath(wxPATH_UNIX);
+    const wxString url1 = wxFileSystem::FileNameToURL(file1);
+    const wxString url2 = wxFileSystem::FileNameToURL(file2);
 
     GError *err = NULL;
 


### PR DESCRIPTION
I tried to open two pdf's with the a filename like "something%2E.pdf".
The issues were:
 * It said the file didn't exist
 * It said the file "s" didn't exist (only the first character was printed)

This PR fixes both:
 * The file was not found because it had an `%` in the name: The file path has to be urlencoded for the poppler to find the correct file. I didn't find a way to do this in wxWidgets so i used glib's functions.
 * c_str() returns a wchar(?) .utf8_str() fixes this for me.

Regards