### PR TITLE
Thumbnail png

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain


### PR DESCRIPTION
Dear Václav, 

for PDF project documentation I wanted to use the wonderful thumbnail images you create for the live viewer. In order to do so, I hacked the code to export these images using a file name base to be specificied in the command line.

You would e.g. call
diff-pdf.exe --output-diff=mydiffpdf.pdf --thumbnail=Diff_thumbnail_page_ file1.pdf file2.pdf

Currently I have done something wrong in the code. It works, but spits out
/usr/src/ports/wxWidgets3.0/wxWidgets3.0-3.0.2.0-2.x86_64/src/wxPython-src-3.0.2.0/src/common/image.cpp(1783): assert "pos != -1" failed in SetRGB(): invalid image coordinates
for each page compared.

After that I use ImageMagick to combine them into 1 PNG:
montage Diff_thumbnail_page_*.png -tile 30x12 -geometry +0+0 Diff_thumbnails.png

Reject the code as you like, maybe it is useful for others, too.

Originally I inteded to put the thumbnails as PDF thumbnails into the output file, but could not yet figure out how to do so with cairo.

