### PR TITLE
omit g_type_init() if glib >= 2.36

### DIFF
--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -828,9 +828,9 @@ int main(int argc, char *argv[])
     wxAppConsole::CheckBuildOptions(WX_BUILD_OPTIONS_SIGNATURE, "diff-pdf");
     wxInitializer wxinitializer(argc, argv);
 
-    #if !GLIB_CHECK_VERSION(2,36,0)
+#if !GLIB_CHECK_VERSION(2,36,0)
     g_type_init();
-    #endif
+#endif
 
     static const wxCmdLineEntryDesc cmd_line_desc[] =
     {

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -828,7 +828,9 @@ int main(int argc, char *argv[])
     wxAppConsole::CheckBuildOptions(WX_BUILD_OPTIONS_SIGNATURE, "diff-pdf");
     wxInitializer wxinitializer(argc, argv);
 
+    #if !GLIB_CHECK_VERSION(2,36,0)
     g_type_init();
+    #endif
 
     static const wxCmdLineEntryDesc cmd_line_desc[] =
     {


### PR DESCRIPTION
"g_type_init has been deprecated since version 2.36"[1]
"the type system is now initialised automatically"[1]

[1] https://developer.gnome.org/gobject/stable/gobject-Type-Information.html#g-type-init