### PR TITLE
support for PDFs that contain multiple page sizes/page orentations

### DIFF
--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -138,7 +138,6 @@ cairo_surface_t *diff_images(cairo_surface_t *s1, cairo_surface_t *s2,
     if ( r1 != r2 )
     {
         changes = true;
-
         cairo_t *cr = cairo_create(diff);
         cairo_set_source_rgb(cr, 1, 1, 1);
         cairo_rectangle(cr, 0, 0, rdiff.width, rdiff.height);
@@ -385,6 +384,9 @@ bool doc_compare(PopplerDocument *doc1, PopplerDocument *doc2,
                           )
                        );
         }
+
+        poppler_page_get_size(poppler_document_get_page(doc1, page), &w, &h);
+        cairo_pdf_surface_set_size (surface_out, w, h);
 
         PopplerPage *page1 = page < pages1
                              ? poppler_document_get_page(doc1, page)

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -387,7 +387,10 @@ bool doc_compare(PopplerDocument *doc1, PopplerDocument *doc2,
         }
 
         poppler_page_get_size(poppler_document_get_page(doc1, page), &w, &h);
-        cairo_pdf_surface_set_size (surface_out, w, h);
+        if ( pdf_output )
+        {
+           cairo_pdf_surface_set_size (surface_out, w, h);
+        }
 
         PopplerPage *page1 = page < pages1
                              ? poppler_document_get_page(doc1, page)

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -138,6 +138,7 @@ cairo_surface_t *diff_images(cairo_surface_t *s1, cairo_surface_t *s2,
     if ( r1 != r2 )
     {
         changes = true;
+
         cairo_t *cr = cairo_create(diff);
         cairo_set_source_rgb(cr, 1, 1, 1);
         cairo_rectangle(cr, 0, 0, rdiff.width, rdiff.height);

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -347,14 +347,13 @@ bool doc_compare(PopplerDocument *doc1, PopplerDocument *doc2,
 {
     bool are_same = true;
 
-    double w, h;
-    poppler_page_get_size(poppler_document_get_page(doc1, 0), &w, &h);
-
     cairo_surface_t *surface_out = NULL;
     cairo_t *cr_out = NULL;
 
     if ( pdf_output )
     {
+        double w, h;
+        poppler_page_get_size(poppler_document_get_page(doc1, 0), &w, &h);
         surface_out = cairo_pdf_surface_create(pdf_output, w, h);
         cr_out = cairo_create(surface_out);
     }
@@ -386,8 +385,9 @@ bool doc_compare(PopplerDocument *doc1, PopplerDocument *doc2,
                        );
         }
 
-        if ( pdf_output )
+        if ( pdf_output && page!= 0)
         {
+            double w, h;
             poppler_page_get_size(poppler_document_get_page(doc1, page), &w, &h);
             cairo_pdf_surface_set_size (surface_out, w, h);
         }

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -389,7 +389,7 @@ bool doc_compare(PopplerDocument *doc1, PopplerDocument *doc2,
         {
             double w, h;
             poppler_page_get_size(poppler_document_get_page(doc1, page), &w, &h);
-            cairo_pdf_surface_set_size (surface_out, w, h);
+            cairo_pdf_surface_set_size(surface_out, w, h);
         }
 
         PopplerPage *page1 = page < pages1

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -385,7 +385,7 @@ bool doc_compare(PopplerDocument *doc1, PopplerDocument *doc2,
                        );
         }
 
-        if ( pdf_output && page != 0)
+        if ( pdf_output && page != 0 )
         {
             double w, h;
             poppler_page_get_size(poppler_document_get_page(doc1, page), &w, &h);

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -386,10 +386,10 @@ bool doc_compare(PopplerDocument *doc1, PopplerDocument *doc2,
                        );
         }
 
-        poppler_page_get_size(poppler_document_get_page(doc1, page), &w, &h);
         if ( pdf_output )
         {
-           cairo_pdf_surface_set_size (surface_out, w, h);
+            poppler_page_get_size(poppler_document_get_page(doc1, page), &w, &h);
+            cairo_pdf_surface_set_size (surface_out, w, h);
         }
 
         PopplerPage *page1 = page < pages1

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -385,7 +385,7 @@ bool doc_compare(PopplerDocument *doc1, PopplerDocument *doc2,
                        );
         }
 
-        if ( pdf_output && page!= 0)
+        if ( pdf_output && page != 0)
         {
             double w, h;
             poppler_page_get_size(poppler_document_get_page(doc1, page), &w, &h);


### PR DESCRIPTION
Adjust the page size for each individual input page size.
This helps with pdfs that contain pages with different sizes/orentations.