### PR TITLE
Add instructions to install dependencies via MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,22 @@ $ sudo apt-get install libpoppler-glib-dev poppler-utils wxgtk3.0-dev
 ```
 
 #### OSX:
-- Install Command Line Tools for Xcode `$ xcode-select --install` and
-[Homebrew](http://brew.sh) to manage dependencies, then:
+Install Command Line Tools for Xcode:
+
+```
+$ xcode-select --install
+```
+
+and install [Homebrew](https://brew.sh) or [MacPorts](https://www.macports.org) to manage dependencies, then:
 
 ```
 $ brew install automake autoconf wxmac poppler cairo
+```
+
+or
+
+```
+$ sudo port install automake autoconf wxWidgets-3.0 poppler cairo
 ```
 
 Note that many more libraries are required on Windows, where none of the


### PR DESCRIPTION
I think it's a good idea to let users know that MacPorts works just as well as Homebrew for managing `diff-pdf`'s dependencies. As a MacPorts user myself, it would have been convenient to have this command to install the dependencies straightaway.