### PR TITLE
Makefile.am: add bootstrap script and README.md to EXTRA_DIST.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ diff_pdf_SOURCES = \
 diff_pdf_CXXFLAGS = $(POPPLER_CFLAGS) $(WX_CXXFLAGS)
 diff_pdf_LDADD = $(POPPLER_LIBS) $(WX_LIBS)
 
-EXTRA_DIST = gtk-zoom-in.xpm gtk-zoom-out.xpm win32/fonts.conf win32/collect-dlls.sh
+EXTRA_DIST = bootstrap gtk-zoom-in.xpm gtk-zoom-out.xpm README.md win32/fonts.conf win32/collect-dlls.sh
 
 windows-dist: diff-pdf-win-$(VERSION).zip
 

--- a/bootstrap
+++ b/bootstrap
@@ -50,7 +50,7 @@ echo "Setting up build system for diff-pdf:"
 echo " - aclocal " && aclocal ${wx+-I} $wx -I admin && \
 echo " - autoconf " && autoconf && \
 echo " - automake " && automake --add-missing --copy --foreign && \
-echo "Build setup successful, type \"configure\" to configure diff-pdf now." && \
+echo "Build setup successful, type \"./configure\" to configure diff-pdf now." && \
 exit 0
 
 echo "Automatic build files setup failed!"


### PR DESCRIPTION
The release tarballs currently don't contain README.md, because the
"dist" makefile target doesn't know about it. This is easily fixed by
adding "README.md" to the existing EXTRA_DIST variable in Makefile.am,
which is nothing other than a list of "extra" files to be included in
the release tarball.