### PR TITLE
Coping with small differences

### DIFF
--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -356,7 +356,7 @@ bool doc_compare(PopplerDocument *doc1, PopplerDocument *doc2,
                  wxProgressDialog *progress = NULL,
                  Gutter *gutter = NULL)
 {
-    bool are_same = true;
+    int pages_differ = 0;
 
     cairo_surface_t *surface_out = NULL;
     cairo_t *cr_out = NULL;
@@ -377,7 +377,6 @@ bool doc_compare(PopplerDocument *doc1, PopplerDocument *doc2,
     {
         if ( g_verbose )
             printf("pages count differs: %d vs %d\n", pages1, pages2);
-        are_same = false;
     }
 
     for ( int page = 0; page < pages_total; page++ )
@@ -455,7 +454,7 @@ bool doc_compare(PopplerDocument *doc1, PopplerDocument *doc2,
 
         if ( !page_same )
         {
-            are_same = false;
+	    pages_differ ++;
 
             if ( g_verbose )
                 printf("page %d differs\n", page);
@@ -475,7 +474,10 @@ bool doc_compare(PopplerDocument *doc1, PopplerDocument *doc2,
         cairo_surface_destroy(surface_out);
     }
 
-    return are_same;
+    if (g_verbose)
+        printf("%d of %d pages differ.\n", pages_differ, pages_total);
+
+    return (pages_differ > 0) || (pages1 != pages2 );
 }
 
 

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -47,6 +47,7 @@
 // ------------------------------------------------------------------------
 
 bool g_verbose = false;
+long g_channel_tolerance = 0;
 
 // Resolution to use for rasterization, in DPI
 #define RESOLUTION  300
@@ -189,7 +190,11 @@ cairo_surface_t *diff_images(cairo_surface_t *s1, cairo_surface_t *s2,
                 unsigned char cg2 = *(data2 + x + 1);
                 unsigned char cb2 = *(data2 + x + 2);
 
-                if ( cr1 != cr2 || cg1 != cg2 || cb1 != cb2 )
+
+		if ( cr1 > (cr2+g_channel_tolerance) || cr2 < (cr2-g_channel_tolerance)
+		  || cg1 > (cg2+g_channel_tolerance) || cg2 < (cg2-g_channel_tolerance)
+		  || cb1 > (cb2+g_channel_tolerance) || cb2 < (cb2-g_channel_tolerance)
+		   )
                 {
                     changes = true;
                     if ( thumbnail )
@@ -863,6 +868,10 @@ int main(int argc, char *argv[])
                   NULL, wxT28("output-diff"), wxT28("output differences to given PDF file"),
                   wxCMD_LINE_VAL_STRING },
 
+        { wxCMD_LINE_OPTION,
+                  NULL, wxT28("channel-tolerance"), wxT28("consider channel values to be equal if within specified tolerance"),
+                  wxCMD_LINE_VAL_NUMBER },
+
         { wxCMD_LINE_SWITCH,
                   NULL, wxT28("view"), wxT28("view the differences in a window") },
 
@@ -918,6 +927,15 @@ int main(int argc, char *argv[])
         g_error_free(err);
         return 3;
     }
+
+    if ( parser.Found(wxT("channel-tolerance"), &g_channel_tolerance) )
+    {
+        if (g_channel_tolerance < 0 || g_channel_tolerance > 255) {
+            fprintf(stderr, "Invalid channel-tolerance: %ld. Valid range is 0(default, exact matching)-255\n", g_channel_tolerance);
+            return 2;
+	}
+    }
+
 
     int retval = 0;
 

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -47,6 +47,7 @@
 // ------------------------------------------------------------------------
 
 bool g_verbose = false;
+bool g_skip_identical = false;
 long g_channel_tolerance = 0;
 
 // Resolution to use for rasterization, in DPI
@@ -327,11 +328,14 @@ bool page_compare(cairo_t *cr_out,
             // by writing unchanged pages in their original form rather than
             // a rasterized one
 
-            poppler_page_render(page1, cr_out);
+            if (!g_skip_identical)
+               poppler_page_render(page1, cr_out);
         }
 
-        cairo_show_page(cr_out);
     }
+
+    if (diff || !g_skip_identical)
+        cairo_show_page(cr_out);
 
     if ( diff )
         cairo_surface_destroy(diff);
@@ -866,6 +870,9 @@ int main(int argc, char *argv[])
         { wxCMD_LINE_SWITCH,
                   wxT28("v"), wxT28("verbose"), wxT28("be verbose") },
 
+        { wxCMD_LINE_SWITCH,
+                  wxT28("s"), wxT28("skip-identical"), wxT28("only output pages with differences") },
+
         { wxCMD_LINE_OPTION,
                   NULL, wxT28("output-diff"), wxT28("output differences to given PDF file"),
                   wxCMD_LINE_VAL_STRING },
@@ -904,6 +911,9 @@ int main(int argc, char *argv[])
 
     if ( parser.Found(wxT("verbose")) )
         g_verbose = true;
+
+    if ( parser.Found(wxT("skip-identical")) )
+        g_skip_identical = true;
 
     wxFileName file1(parser.GetParam(0));
     wxFileName file2(parser.GetParam(1));


### PR DESCRIPTION
I'm using diff-pdf and often struggle to see where some pages differ. For that, I've introduced several options (each as a separate commite).

NOTE: The interactive mode doesn't work for me. I'm only using --output-diff, which is perfectly fine for my use case. However, I could not test --view mode.

I'm regularily diffing large PDF files with only very few small changes to verify there are not unintended differences. I often struggle to see the differences.

--skip-identical only outputs files with actual differences, so that each page in the output is known to have a difference.

However, after that I still got many pages without visual differences. I tried a lot but what actually worked was to allow for a tolerance on the channel comparison. Even a small tolerance reduces the number of false positives dramatically in my case (--channel-tolerance=1).

While researching, I've also introduced --mark-differences to make (small) differences more easy to spot. I just kept that because it was helpful for me.

Finally I added some more output to --verbose to more easily see how the --channel-tolerance affects the output.

I'm not very deep into cairo and co, so you'd need to have a very close look.