### PR TITLE
poppler-cairo is no more

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ AC_LANG(C++)
 dnl === Library checks ===
 
 PKG_CHECK_MODULES(POPPLER,
-                  [poppler-cairo >= 0.10 poppler-glib >= 0.10 cairo-pdf])
+                  [poppler-glib >= 0.10 cairo-pdf])
 
 AM_OPTIONS_WXCONFIG
 AM_PATH_WXCONFIG([3.0.0], [wxfound=1], [wxfound=0], [core,base])


### PR DESCRIPTION
It was removed in poppler 0.18.1:
https://github.com/freedesktop/poppler/blob/acf4c8e1d1253f2c82c8e5ac009534b52deec88d/NEWS#L2271