### PR TITLE
Reflect renaming of package from Ubuntu 20.10 on

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $ sudo yum install wxGTK wxGTK-devel poppler-glib poppler-glib-devel
 
 ```
 $ sudo apt-get install make automake g++
-$ sudo apt-get install libpoppler-glib-dev poppler-utils libwxgtk3.0-dev
+$ sudo apt-get install libpoppler-glib-dev poppler-utils libwxgtk3.0-gtk3-dev
 ```
 
 #### macOS:


### PR DESCRIPTION
https://askubuntu.com/questions/1241217/package-libwxgtk3-0-dev-has-no-installation-candidate-on-ubuntu-20-04?newreg=79d5eb7693da41dea39dfb5f61710256

Needed to use a different package name for compiling