### PR TITLE
Create PDF Compare.ps1

### DIFF
--- a/PDF Compare.ps1
+++ b/PDF Compare.ps1
@@ -1,0 +1,38 @@
+If (!(Test-Path "$PSScriptRoot\diff-pdf.exe")) {
+	echo ""; echo "diff-pdf.exe not found in '$PSScriptRoot'. Exiting."; echo ""; Pause; Exit
+}
+
+If (($args).count -eq 0) {
+  # Requires InvocationName instead of MyCommand due to being called as an argument of powershell.exe via a shortcut
+	$ScriptName = (Get-Item $MyInvocation.InvocationName).BaseName
+	If (Test-Path "$env:appdata\Microsoft\Windows\SendTo\$ScriptName.lnk") {
+		Remove-Item "$env:appdata\Microsoft\Windows\SendTo\$ScriptName.lnk"
+	}
+	$s=(New-Object -COM WScript.Shell).CreateShortcut("$env:appdata\Microsoft\Windows\SendTo\$ScriptName.lnk")
+	$s.TargetPath="powershell.exe"
+	$s.Arguments="-File `"$PSScriptRoot\$ScriptName.ps1`""
+	$s.Save()
+	echo ""; echo "SendTo shortcut created"; echo ""; Timeout /T 3; Exit
+}
+
+If (($args).count -ne 2) {
+	echo ""
+	If (($args).count -lt 2) {
+		echo "Not enough files selected for comparison. Select TWO PDFs and try again."
+	} else {
+		echo "Too many files selected for comparison. Select TWO PDFs and try again."
+	}
+	echo ""; Pause; Exit
+}
+
+ForEach ($item in $args) {
+	If ([IO.Path]::GetExtension($item) -ne ".pdf") {
+		echo ""; echo "One or both selected files is NOT a PDF. Select two PDFs and try again."; echo ""; Pause; Exit
+	}
+}
+
+# Uncomment this line and comment next line to view differences in diff-pdf's viewer (does NOT create additional file)
+& "$PSScriptRoot\diff-pdf.exe" --view $args[0] $args[1]
+
+# Uncomment this line and comment previous line to create new PDF file showing differences between files. File will be named "diff_{date_time}" where {date_time} is in yyyy-MM-dd_HH.mm.ss format
+#$date_time = Get-Date -Format "yyyy-MM-dd_HH.mm.ss"; & "$PSScriptRoot\diff-pdf.exe" --output-diff=diff_$date_time.pdf $args[0] $args[1]; $PDF_Dir=Split-Path -Path $args[0] -Parent; Do {Start-Sleep -Seconds 1} Until (Test-Path "$PDF_Dir\diff_$date_time.pdf"); & "$PDF_Dir\diff_$date_time.pdf"


### PR DESCRIPTION
This is a script to make the use of diff-pdf much easier. Instead of requiring the use of command line, remembering the command usage, and typing potentially long paths and filenames, it allows the user to simply select two files and send them to diff-pdf to be processed. It does this by first adding a shortcut to itself to the SendTo folder when run on its own, and then when the user selects two PDF files in Explorer and right-clicks them then selects "Send to > PDF Compare*" it will run diff-pdf with those files as arguments and either the "--view" or "--output-diff" argument, whichever is uncommented.

A few notes:

*The scripts adds a shortcut to SendTo with the same name as the script, so if the script's name is changed and it is run directly, the name in the Send to submenu of the context menu will be whatever it was changed to, NOT "PDF Compare"

- The main page for diff-pdf says "If given the --pdf option..." but then the example given uses the "--output-diff" option, and AFAICT there is no "--pdf" option.

- The main page also states that the default is to simply give an exit code of 0 or 1, which I intended to use to first check if the files are even different and only run the --view or --output-diff commands if they are, but regardless of what I tried, it always resulted in a 0, even with different files.

- If using the "--output-diff" command, it appends the date and time to the filename to avoid accidental overwriting of any files, to allow for multiple diff files, and to make it easier to find

- The ability to actually use this file comes with the same caveats of any PowerShell script (.ps1) file, i.e. you may need to change the execution policy and/or the default action when running a PS script.