### PR TITLE
Start gitignore comments on their own lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,7 @@ autom4te.cache
 aclocal.m4
 mingw
 
-*.o # compiled (and unlinked) objects
-diff-pdf # the final binary
+# compiled (and unlinked) objects
+*.o
+# the final binary
+diff-pdf


### PR DESCRIPTION
According to the git documentation, comments must begin on the first character of a line. See https://git-scm.com/docs/gitignore:

A line starting with # serves as a comment.