### PR TITLE
codespell: config, workflow + 2 typos fixed

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+#
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,22 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/admin/wxwin.m4
+++ b/admin/wxwin.m4
@@ -625,7 +625,7 @@ AC_DEFUN([WX_STANDARD_OPTIONS],
         dnl   will build your library in static mode against the first available
         dnl   shared build of wxWidgets.
         dnl
-        dnl   Note that's not possible to do the viceversa:
+        dnl   Note that's not possible to do the vice-versa:
         dnl
         dnl      ./configure --enable-shared --without-wxshared
         dnl

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -141,7 +141,7 @@ cairo_surface_t *diff_images(int page, cairo_surface_t *s1, cairo_surface_t *s2,
         thumbnail_scale = float(thumbnail_width) / float(rdiff.width);
         thumbnail_height = int(rdiff.height * thumbnail_scale);
         thumbnail->Create(thumbnail_width, thumbnail_height);
-        // initalize the thumbnail with a white rectangle:
+        // initialize the thumbnail with a white rectangle:
         thumbnail->SetRGB(wxRect(), 255, 255, 255);
     }
 


### PR DESCRIPTION
[codespell](https://github.com/codespell-project/codespell) is a nice tool to detect and fix commonly made typos.  In this PR I propose a rudimentary config to avoid checking `.git` and few other file types which generally should be skipped, github action which would fail if a typo identified in the codebase, and then a single run of `codespell -w` to fix up detected typos (the commit message is produced by [datalad run](https://handbook.datalad.org/en/latest/basics/basics-run.html) so it captures how the changes in the commit came about)