### PR TITLE
Add steps for Debian 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ $ sudo yum groupinstall "Development Tools"
 $ sudo yum install wxGTK wxGTK-devel poppler-glib poppler-glib-devel
 ```
 
-#### Ubuntu:
+#### Ubuntu/(Debian <= 11):
 
 ```
 $ sudo apt-get install make automake g++
 $ sudo apt-get install libpoppler-glib-dev poppler-utils libwxgtk3.0-gtk3-dev
 ```
 
-#### Debian 12:
+#### Debian >= 12:
 
 ```
 $ sudo apt-get install make automake g++

--- a/README.md
+++ b/README.md
@@ -91,19 +91,20 @@ $ sudo yum groupinstall "Development Tools"
 $ sudo yum install wxGTK wxGTK-devel poppler-glib poppler-glib-devel
 ```
 
-#### Ubuntu/(Debian <= 11):
+#### Ubuntu 24.04 / Debian 12 or newer:
+
+```
+$ sudo apt-get install make automake g++
+$ sudo apt-get install libpoppler-glib-dev poppler-utils libwxgtk3.2-dev
+```
+
+#### Older versions of Ubuntu / Debian:
 
 ```
 $ sudo apt-get install make automake g++
 $ sudo apt-get install libpoppler-glib-dev poppler-utils libwxgtk3.0-gtk3-dev
 ```
 
-#### Debian >= 12:
-
-```
-$ sudo apt-get install make automake g++
-$ sudo apt-get install libpoppler-glib-dev poppler-utils libwxgtk-webview3.2-1 libwxgtk-webview3.2-dev
-```
 #### macOS:
 Install Command Line Tools for Xcode:
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ $ sudo apt-get install make automake g++
 $ sudo apt-get install libpoppler-glib-dev poppler-utils libwxgtk3.0-gtk3-dev
 ```
 
+#### Debian 12:
+
+```
+$ sudo apt-get install make automake g++
+$ sudo apt-get install libpoppler-glib-dev poppler-utils libwxgtk-webview3.2-1 libwxgtk-webview3.2-dev
+```
 #### macOS:
 Install Command Line Tools for Xcode:
 


### PR DESCRIPTION
'libwxgtk3.0-gtk3-dev' is unavailable for debian 12, replaced with appropriate packages 