### PR TITLE
Left/right document isolated view with hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This opens a window that lets you view the files' pages and zoom in on details.
 It is also possible to shift the two pages relatively to each other using
 Ctrl-arrows (Cmd-arrows on MacOS). This is useful for identifying translation-only differences.
 
+You can also use Ctrl < and Ctrl > (Cmd < and Cmd > on MacOS) show the left and right documents respecively. Ctrl d to return back to the diff view.
+
 See the output of `$ diff-pdf --help` for complete list of options.
 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This opens a window that lets you view the files' pages and zoom in on details.
 It is also possible to shift the two pages relatively to each other using
 Ctrl-arrows (Cmd-arrows on MacOS). This is useful for identifying translation-only differences.
 
-You can also use Ctrl < and Ctrl > (Cmd < and Cmd > on MacOS) show the left and right documents respecively. Ctrl d to return back to the diff view.
+You can also use `Ctrl+<` and `Ctrl+>` (`Cmd+<` and `Cmd+>` on MacOS) show the left and right documents respecively. `Ctrl+D` to return back to the diff view.
 
 See the output of `$ diff-pdf --help` for complete list of options.
 

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -559,6 +559,10 @@ const int ID_DIFF_DOC = wxNewId();
 #define BMP_OFFSET_UP      BMP_ARTPROV(wxART_GO_UP)
 #define BMP_OFFSET_DOWN    BMP_ARTPROV(wxART_GO_DOWN)
 
+#define BMP_LEFT_DOC       BMP_ARTPROV(wxART_GO_BACK)
+#define BMP_RIGHT_DOC      BMP_ARTPROV(wxART_GO_FORWARD)
+#define BMP_DIFF_DOC       BMP_ARTPROV(wxART_REDO)
+
 #ifdef __WXGTK__
     #define BMP_ZOOM_IN    BMP_ARTPROV("gtk-zoom-in")
     #define BMP_ZOOM_OUT   BMP_ARTPROV("gtk-zoom-out")
@@ -608,12 +612,12 @@ public:
                          "Offset one of the pages up (Ctrl up)");
         toolbar->AddTool(ID_OFFSET_DOWN, "", BMP_OFFSET_DOWN,
                          "Offset one of the pages down (Ctrl down)");
-        toolbar->AddTool(ID_LEFT_DOC, "Left document", BMP_ARTPROV(wxART_GO_BACK),
-                         "Show left document (Ctrl <)");
-        toolbar->AddTool(ID_DIFF_DOC, "Diff document", BMP_ARTPROV(wxART_REDO),
-                         "Show diff document (Ctrl d)");
-        toolbar->AddTool(ID_RIGHT_DOC, "Right document", BMP_ARTPROV(wxART_GO_FORWARD),
-                         "Show right document (Ctrl >)");
+        toolbar->AddTool(ID_LEFT_DOC, "Left document", BMP_LEFT_DOC,
+                         "Show left document (Ctrl+<)");
+        toolbar->AddTool(ID_DIFF_DOC, "Diff document", BMP_DIFF_DOC,
+                         "Show diff document (Ctrl+d)");
+        toolbar->AddTool(ID_RIGHT_DOC, "Right document", BMP_RIGHT_DOC,
+                         "Show right document (Ctrl+>)");
 
         toolbar->Realize();
         SetToolBar(toolbar);
@@ -719,7 +723,7 @@ private:
         switch ( m_display_mode )
         {
             case SHOW_LEFT_DOCUMENT:
-            // 
+                // Try showing the left document; if not available, fall back
                 if ( img1 )
                     m_viewer->Set(img1);
                 else if ( img2 )
@@ -729,6 +733,7 @@ private:
                 break;
 
             case SHOW_RIGHT_DOCUMENT:
+                // Try showing the right document; if not available, fall back
                 if ( img2 )
                     m_viewer->Set(img2);
                 else if ( img1 )
@@ -832,24 +837,27 @@ private:
         DoUpdatePage();
     }
 
+    void ResetOffset()
+    {
+        m_offset = wxPoint(0, 0);
+        DoUpdatePage();
+    }
+
     void OnShowLeftDocument(wxCommandEvent&)
     {
         m_display_mode = SHOW_LEFT_DOCUMENT;
-        m_offset = wxPoint(0, 0);
         DoUpdatePage();
     }
 
     void OnShowDiffDocument(wxCommandEvent&)
     {
         m_display_mode = SHOW_DIFF_DOCUMENT;
-        m_offset = wxPoint(0, 0);
         DoUpdatePage();
     }
 
     void OnShowRightDocument(wxCommandEvent&)
     {
         m_display_mode = SHOW_RIGHT_DOCUMENT;
-        m_offset = wxPoint(0, 0);
         DoUpdatePage();
     }
 
@@ -883,9 +891,9 @@ BEGIN_EVENT_TABLE(DiffFrame, wxFrame)
     EVT_TOOL     (ID_OFFSET_RIGHT, DiffFrame::OnOffsetRight)
     EVT_TOOL     (ID_OFFSET_UP,    DiffFrame::OnOffsetUp)
     EVT_TOOL     (ID_OFFSET_DOWN,  DiffFrame::OnOffsetDown)
-    EVT_TOOL     (ID_LEFT_DOC,    DiffFrame::OnShowLeftDocument)
-    EVT_TOOL     (ID_DIFF_DOC,    DiffFrame::OnShowDiffDocument)
-    EVT_TOOL     (ID_RIGHT_DOC,   DiffFrame::OnShowRightDocument)
+    EVT_TOOL     (ID_LEFT_DOC,     DiffFrame::OnShowLeftDocument)
+    EVT_TOOL     (ID_DIFF_DOC,     DiffFrame::OnShowDiffDocument)
+    EVT_TOOL     (ID_RIGHT_DOC,    DiffFrame::OnShowRightDocument)
 END_EVENT_TABLE()
 
 

--- a/diff-pdf.cpp
+++ b/diff-pdf.cpp
@@ -42,6 +42,14 @@
 #include <wx/progdlg.h>
 #include <wx/filesys.h>
 
+
+enum DisplayMode
+{
+    SHOW_DIFF_DOCUMENT,
+    SHOW_LEFT_DOCUMENT,
+    SHOW_RIGHT_DOCUMENT
+};
+
 // ------------------------------------------------------------------------
 // PDF rendering functions
 // ------------------------------------------------------------------------
@@ -537,6 +545,9 @@ const int ID_OFFSET_RIGHT = wxNewId();
 const int ID_OFFSET_UP = wxNewId();
 const int ID_OFFSET_DOWN = wxNewId();
 const int ID_GUTTER = wxNewId();
+const int ID_LEFT_DOC = wxNewId();
+const int ID_RIGHT_DOC = wxNewId();
+const int ID_DIFF_DOC = wxNewId();
 
 #define BMP_ARTPROV(id) wxArtProvider::GetBitmap(id, wxART_TOOLBAR)
 
@@ -597,11 +608,17 @@ public:
                          "Offset one of the pages up (Ctrl up)");
         toolbar->AddTool(ID_OFFSET_DOWN, "", BMP_OFFSET_DOWN,
                          "Offset one of the pages down (Ctrl down)");
+        toolbar->AddTool(ID_LEFT_DOC, "Left document", BMP_ARTPROV(wxART_GO_BACK),
+                         "Show left document (Ctrl <)");
+        toolbar->AddTool(ID_DIFF_DOC, "Diff document", BMP_ARTPROV(wxART_REDO),
+                         "Show diff document (Ctrl d)");
+        toolbar->AddTool(ID_RIGHT_DOC, "Right document", BMP_ARTPROV(wxART_GO_FORWARD),
+                         "Show right document (Ctrl >)");
 
         toolbar->Realize();
         SetToolBar(toolbar);
 
-        wxAcceleratorEntry accels[8];
+        wxAcceleratorEntry accels[11];
         accels[0].Set(wxACCEL_NORMAL, WXK_PAGEUP, ID_PREV_PAGE);
         accels[1].Set(wxACCEL_NORMAL, WXK_PAGEDOWN, ID_NEXT_PAGE);
         accels[2].Set(wxACCEL_CTRL, (int)'=', ID_ZOOM_IN);
@@ -610,8 +627,11 @@ public:
         accels[5].Set(wxACCEL_CTRL, WXK_RIGHT, ID_OFFSET_RIGHT);
         accels[6].Set(wxACCEL_CTRL, WXK_UP, ID_OFFSET_UP);
         accels[7].Set(wxACCEL_CTRL, WXK_DOWN, ID_OFFSET_DOWN);
+        accels[8].Set(wxACCEL_CTRL, (int)',',  ID_LEFT_DOC);
+        accels[9].Set(wxACCEL_CTRL, (int)'.', ID_RIGHT_DOC);
+        accels[10].Set(wxACCEL_CTRL, (int)'d', ID_DIFF_DOC);
 
-        wxAcceleratorTable accel_table(8, accels);
+        wxAcceleratorTable accel_table(11, accels);
         SetAcceleratorTable(accel_table);
 
         m_gutter = new Gutter(this, ID_GUTTER);
@@ -695,8 +715,32 @@ private:
                                     m_offset.x, m_offset.y,
                                     &thumbnail, Gutter::WIDTH
                                 );
+        // Render page according to the current display mode
+        switch ( m_display_mode )
+        {
+            case SHOW_LEFT_DOCUMENT:
+            // 
+                if ( img1 )
+                    m_viewer->Set(img1);
+                else if ( img2 )
+                    m_viewer->Set(img2);
+                else
+                    m_viewer->Set(NULL);
+                break;
 
-        m_viewer->Set(diff ? diff : img1);
+            case SHOW_RIGHT_DOCUMENT:
+                if ( img2 )
+                    m_viewer->Set(img2);
+                else if ( img1 )
+                    m_viewer->Set(img1);
+                else
+                    m_viewer->Set(NULL);
+                break;
+
+            case SHOW_DIFF_DOCUMENT:
+            default:
+                m_viewer->Set(diff ? diff : img1);
+        }
 
         // Always update the diff map. It will be all-white if there were
         // no differences.
@@ -788,6 +832,27 @@ private:
         DoUpdatePage();
     }
 
+    void OnShowLeftDocument(wxCommandEvent&)
+    {
+        m_display_mode = SHOW_LEFT_DOCUMENT;
+        m_offset = wxPoint(0, 0);
+        DoUpdatePage();
+    }
+
+    void OnShowDiffDocument(wxCommandEvent&)
+    {
+        m_display_mode = SHOW_DIFF_DOCUMENT;
+        m_offset = wxPoint(0, 0);
+        DoUpdatePage();
+    }
+
+    void OnShowRightDocument(wxCommandEvent&)
+    {
+        m_display_mode = SHOW_RIGHT_DOCUMENT;
+        m_offset = wxPoint(0, 0);
+        DoUpdatePage();
+    }
+
     void OnOffsetLeft(wxCommandEvent&) { DoOffset(-1, 0); }
     void OnOffsetRight(wxCommandEvent&) { DoOffset(1, 0); }
     void OnOffsetUp(wxCommandEvent&) { DoOffset(0, -1); }
@@ -803,6 +868,7 @@ private:
     int m_diff_count;
     int m_cur_page;
     wxPoint m_offset;
+    DisplayMode m_display_mode;
 };
 
 BEGIN_EVENT_TABLE(DiffFrame, wxFrame)
@@ -817,6 +883,9 @@ BEGIN_EVENT_TABLE(DiffFrame, wxFrame)
     EVT_TOOL     (ID_OFFSET_RIGHT, DiffFrame::OnOffsetRight)
     EVT_TOOL     (ID_OFFSET_UP,    DiffFrame::OnOffsetUp)
     EVT_TOOL     (ID_OFFSET_DOWN,  DiffFrame::OnOffsetDown)
+    EVT_TOOL     (ID_LEFT_DOC,    DiffFrame::OnShowLeftDocument)
+    EVT_TOOL     (ID_DIFF_DOC,    DiffFrame::OnShowDiffDocument)
+    EVT_TOOL     (ID_RIGHT_DOC,   DiffFrame::OnShowRightDocument)
 END_EVENT_TABLE()
 
 


### PR DESCRIPTION
Sometimes the red/blue diff view is a bit confusing and its easier to just check the left/right documents individually. This PR adds buttons to toggle between 3 modes:
* Left Document
* Diff 
* Right Document

You can also use `Ctrl <` and `Ctrl >` to hot switch between the Left/Right view. 

`Ctrl d` returns to the default Diff view.

Futher more, the `Ctrl d` sets the offsets to 0, 0  (acts as a clear in case you want to quickly reset the offset)


## Futher Improvements
[ ] Show the names of the current document view (Left: file.pdf/ Right other.pdf / Diff)
[ ] Handle Missing pages (currently the diff doesn't handle missing pages and just shows changes for all subsequent pages)